### PR TITLE
Handle long messages in event parser

### DIFF
--- a/internal/parser/reader_parser.go
+++ b/internal/parser/reader_parser.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-var splitFunc bufio.SplitFunc = func(data []byte, _ bool) (advance int, token []byte, err error) {
+var splitFunc bufio.SplitFunc = func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if len(data) == 0 {
 		return
 	}
@@ -20,6 +20,12 @@ var splitFunc bufio.SplitFunc = func(data []byte, _ bool) (advance int, token []
 		if advance == len(data) || (isNewlineChar(data[advance]) && index > 0) {
 			break
 		}
+	}
+
+	if advance == len(data) && !atEOF {
+		// We have reached the end of the buffer but have not yet seen two consecutive
+		// newline sequences, so we request more data.
+		return 0, nil, nil
 	}
 
 	if l := len(data); advance < l {

--- a/internal/parser/reader_parser_test.go
+++ b/internal/parser/reader_parser_test.go
@@ -30,6 +30,8 @@ func TestReaderParser(t *testing.T) {
 		expected []parser.Field
 	}
 
+	longString := strings.Repeat("abcdefghijklmnopqrstuvwxyz", 193)
+
 	tests := []test{
 		{
 			name: "Valid input",
@@ -65,6 +67,14 @@ data: still, here's some data: you deserve it
 				{},
 				newEventField(t, "something glitched before why are there two newlines"),
 				newDataField(t, "still, here's some data: you deserve it"),
+			},
+		},
+		{
+			name:  "Valid input with long string",
+			input: strings.NewReader("\nid:2\ndata:" + longString + "\n"),
+			expected: []parser.Field{
+				newIDField(t, "2"),
+				newDataField(t, longString),
 			},
 		},
 		{

--- a/internal/parser/split_func_test.go
+++ b/internal/parser/split_func_test.go
@@ -34,3 +34,33 @@ func TestSplitFunc(t *testing.T) {
 		t.Fatalf("wrong tokens:\nreceived: %#v\nexpected: %#v", tokens, expected)
 	}
 }
+
+func TestSplitFuncWithLongLine(t *testing.T) {
+	t.Parallel()
+
+	longString := strings.Repeat("abcdef\rghijklmn\nopqrstu\r\nvwxyz", 193)
+	text := longString + "\n\n" + longString + "\r\r" + longString + "\r\n\r\n" + longString
+	r := strings.NewReader(text)
+	s := bufio.NewScanner(r)
+	s.Split(splitFunc)
+
+	expected := []string{
+		longString + "\n\n",
+		longString + "\r\r",
+		longString + "\r\n\r\n",
+		longString,
+	}
+	tokens := make([]string, 0, len(expected))
+
+	for s.Scan() {
+		tokens = append(tokens, s.Text())
+	}
+
+	if s.Err() != nil {
+		t.Fatalf("an error occurred: %v", s.Err())
+	}
+
+	if !reflect.DeepEqual(tokens, expected) {
+		t.Fatalf("wrong tokens:\nreceived: %#v\nexpected: %#v", tokens, expected)
+	}
+}


### PR DESCRIPTION
This PR fixes a bug that causes the `go-sse` client to drop messages that are longer than 4096 bytes with an Unexpected EOF error.

The issue here is that the `Scanner` that gets used to fill the input buffer for the byte parser (which gets used to extract fields) may not call the `SplitFunc` with a buffer containing a full token. In that case, the split function needs to request more data, signalling to the `Scanner` to call the `SplitFunc ` again with a larger buffer.

This PR includes a new test case in `TestReaderParser` that fails if this change is not present, along with a new test in `internal/parser/split_func_test.go`.